### PR TITLE
Replace "master" to "main" for selected recipes

### DIFF
--- a/recipes-extended/cracklib/cracklib_2.9.8.bbappend
+++ b/recipes-extended/cracklib/cracklib_2.9.8.bbappend
@@ -1,0 +1,5 @@
+# Override the brach to use "main" instead of "master"
+SRC_URI = "git://github.com/cracklib/cracklib;protocol=https;branch=main \
+           file://0001-packlib.c-support-dictionary-byte-order-dependent.patch \
+           file://0002-craklib-fix-testnum-and-teststr-failed.patch \
+           "

--- a/recipes-graphics/glslang/glslang_1.3.204.1.bbappend
+++ b/recipes-graphics/glslang/glslang_1.3.204.1.bbappend
@@ -1,0 +1,3 @@
+# Override the branch to use "main" instead of "master"
+SRC_URI = "git://github.com/KhronosGroup/glslang.git;protocol=https;branch=main \
+           file://0001-generate-glslang-pkg-config.patch"

--- a/recipes-graphics/spir/spirv-headers_1.3.204.1.bbappend
+++ b/recipes-graphics/spir/spirv-headers_1.3.204.1.bbappend
@@ -1,0 +1,2 @@
+# Override the branch to use "main" instead of "master"
+SRC_URI = "git://github.com/KhronosGroup/SPIRV-Headers;protocol=https;branch=main"

--- a/recipes-graphics/vulkan/vulkan-loader_1.2.182.0.bbappend
+++ b/recipes-graphics/vulkan/vulkan-loader_1.2.182.0.bbappend
@@ -1,0 +1,2 @@
+# Override the branch to use "main" instead of "master"
+SRC_URI = "git://github.com/KhronosGroup/Vulkan-Loader.git;branch=main;protocol=https"

--- a/recipes-support/bmap-tools/bmap-tools_git.bbappend
+++ b/recipes-support/bmap-tools/bmap-tools_git.bbappend
@@ -1,0 +1,2 @@
+# Override the branch to use "main" instead of "master"
+SRC_URI = "git://github.com/intel/${BPN};branch=main;protocol=https"


### PR DESCRIPTION
Fixes #4 

The following recipes have been updated with `main` instead of `master` branch:
- `cracklib_2.9.8.bb`
- `vulkan_loader_1.2.182.0.bb`
- `spirv_headers_1.3.204.1.bb`
- `glslang_1.3.204.1.bb`
- `bmap_tools_git.bb`

On the other hand, `linux_imx_header_5.15.bb` has not been touched since the problem was just a networking issue during the `do_fetch` step.
The previously [proposed fix](https://github.com/System-Electronics/meta-sysele-nxp-5.15.71/issues/4#issuecomment-2421750344) was just a "no-op" and the underlying issue resolved itself after relaunching the build.