### PR TITLE
Root home fixes

### DIFF
--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,10 @@
+do_install:append() {
+    # create "/root" folder as symlink to ${ROOT_HOME}
+    ROOT_SYM="/root"
+    if [ "${ROOT_HOME}" != "${ROOT_SYM}" ]; then
+        if [ -d "${D}${ROOT_SYM}" ]; then
+            bbfatal "Error while trying to create ${ROOT_SYM} as symlink to ${ROOT_HOME}, it is already a folder!"
+        fi
+        ln -sfr ${D}${ROOT_HOME} ${D}${ROOT_SYM}
+    fi
+}

--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -1,0 +1,11 @@
+update_file() {
+    if ! grep -q "$1" $3; then
+        bbfatal $1 not found in $3
+    fi
+    sed -i -e "s,$1,$2," $3
+}
+
+do_install:append() {
+    # Inside meta-imx, NXP restored "root" as the default user, but they forgot to update the WorkingDirectory
+    update_file "WorkingDirectory=/home/weston" "WorkingDirectory=/home/root" ${D}${systemd_system_unitdir}/weston.service
+}


### PR DESCRIPTION
- Set /root as a symlink to ROOT_HOME (aka /home/root)
- Set weston working dir to /home/root