### PR TITLE
RAM Variants (2G, 4G, 8G) + Custom WKS

### DIFF
--- a/conf/machine/astrial-2gb-imx8mp.conf
+++ b/conf/machine/astrial-2gb-imx8mp.conf
@@ -1,0 +1,10 @@
+#@TYPE: Machine
+#@NAME: System Electronics Astrial i.MX 8M Plus with 2GB LPDDR4
+#@SOC: i.MX8MP
+#@DESCRIPTION: Machine configuration for System Electronics Astrial i.MX 8M Plus board with 2GB LPDDR4
+#@MAINTAINER: System Eletronics <info@systemelectronics.com>
+
+require conf/machine/include/astrial-imx8mp.inc
+
+# u-boot configuration
+UBOOT_CONFIG_BASENAME = "imx8mp_astrial_2gb"

--- a/conf/machine/astrial-4gb-imx8mp.conf
+++ b/conf/machine/astrial-4gb-imx8mp.conf
@@ -1,0 +1,10 @@
+#@TYPE: Machine
+#@NAME: System Electronics Astrial i.MX 8M Plus with 4GB LPDDR4
+#@SOC: i.MX8MP
+#@DESCRIPTION: Machine configuration for System Electronics Astrial i.MX 8M Plus board with 4GB LPDDR4
+#@MAINTAINER: System Eletronics <info@systemelectronics.com>
+
+require conf/machine/include/astrial-imx8mp.inc
+
+# u-boot configuration
+UBOOT_CONFIG_BASENAME = "imx8mp_astrial_4gb"

--- a/conf/machine/astrial-8gb-imx8mp.conf
+++ b/conf/machine/astrial-8gb-imx8mp.conf
@@ -1,0 +1,10 @@
+#@TYPE: Machine
+#@NAME: System Electronics Astrial i.MX 8M Plus with 8GB LPDDR4
+#@SOC: i.MX8MP
+#@DESCRIPTION: Machine configuration for System Electronics Astrial i.MX 8M Plus board with 8GB LPDDR4
+#@MAINTAINER: System Eletronics <info@systemelectronics.com>
+
+require conf/machine/include/astrial-imx8mp.inc
+
+# u-boot configuration
+UBOOT_CONFIG_BASENAME = "imx8mp_astrial_8gb"

--- a/conf/machine/astrial-imx8mp.conf
+++ b/conf/machine/astrial-imx8mp.conf
@@ -42,3 +42,5 @@ IMX_DEFAULT_BSP = "nxp"
 
 # we need to change the default serial for TF-A
 ATF_BOOT_UART_BASE = "0x30860000"
+
+WKS_FILE = "${MACHINE}-bootpart.wks.in"

--- a/conf/machine/include/astrial-imx8mp.inc
+++ b/conf/machine/include/astrial-imx8mp.inc
@@ -37,4 +37,4 @@ IMX_DEFAULT_BSP = "nxp"
 # we need to change the default serial for TF-A
 ATF_BOOT_UART_BASE = "0x30860000"
 
-WKS_FILE = "${MACHINE}-bootpart.wks.in"
+WKS_FILE = "astrial-imx8mp-bootpart.wks.in"

--- a/conf/machine/include/astrial-imx8mp.inc
+++ b/conf/machine/include/astrial-imx8mp.inc
@@ -1,9 +1,3 @@
-#@TYPE: Machine
-#@NAME: System Electronics Astrial i.MX 8M Plus with LPDDR4
-#@SOC: i.MX8MP
-#@DESCRIPTION: Machine configuration for System Electronics Astrial i.MX 8M Plus board with LPDDR4
-#@MAINTAINER: Koan software <info@koansoftware.com>
-
 require conf/machine/include/imx8mp-evk.inc
 
 # kernel device tree

--- a/recipes-bsp/u-boot/u-boot-imx_2022.04.bbappend
+++ b/recipes-bsp/u-boot/u-boot-imx_2022.04.bbappend
@@ -4,8 +4,8 @@
 
 # change the NXP repo with the System Electronics custom one
 UBOOT_SRC = "git://github.com/System-Electronics/uboot-imx-lf-5.15.71;protocol=https"
-SRCBRANCH = "main"
-SRCREV = "b60485fa296762b0f06c0ec2cd94235c8adf6e93"
+SRCBRANCH = "feature/2g-4g-ram"
+SRCREV = "008a0bb391e1663b5c30824bdf92d7e4b9e202ee"
 
 # set local version
 LOCALVERSION = "-sysele"

--- a/recipes-bsp/u-boot/u-boot-imx_2022.04.bbappend
+++ b/recipes-bsp/u-boot/u-boot-imx_2022.04.bbappend
@@ -4,8 +4,8 @@
 
 # change the NXP repo with the System Electronics custom one
 UBOOT_SRC = "git://github.com/System-Electronics/uboot-imx-lf-5.15.71;protocol=https"
-SRCBRANCH = "feature/2g-4g-ram"
-SRCREV = "407f5035d29df4bfc3e5fe884cb4edb5abcb6ad6"
+SRCBRANCH = "main"
+SRCREV = "852d4dbd83aaca1456039323f49bb0a18b0c4472"
 
 # set local version
 LOCALVERSION = "-sysele"

--- a/recipes-bsp/u-boot/u-boot-imx_2022.04.bbappend
+++ b/recipes-bsp/u-boot/u-boot-imx_2022.04.bbappend
@@ -5,7 +5,7 @@
 # change the NXP repo with the System Electronics custom one
 UBOOT_SRC = "git://github.com/System-Electronics/uboot-imx-lf-5.15.71;protocol=https"
 SRCBRANCH = "feature/2g-4g-ram"
-SRCREV = "008a0bb391e1663b5c30824bdf92d7e4b9e202ee"
+SRCREV = "407f5035d29df4bfc3e5fe884cb4edb5abcb6ad6"
 
 # set local version
 LOCALVERSION = "-sysele"

--- a/recipes-images/images/system-astrial-image.bb
+++ b/recipes-images/images/system-astrial-image.bb
@@ -45,3 +45,12 @@ IMAGE_INSTALL:append = " opencv opencv-dev libopencv-core-dev libopencv-highgui-
 #################################################################################################################
 ## Tools Extra
 IMAGE_INSTALL:append = " git joe du-dust python3-shtab python3-tldr custom-shell dtc keyctl-caam se05x python3-pyqt6"
+
+# Rootfs will automatically resize to fill entire space by itself, but leave some extra space for initial operations
+# Use overhead factor instead of extra space since there are some problems with the rootfs size estimation which lead to:
+#   Copying files into the device: __populate_fs: Could not allocate block in ext2 filesystem while writing file "..."
+IMAGE_OVERHEAD_FACTOR = "1.05"
+IMAGE_ROOTFS_EXTRA_SPACE = "0"
+# compute maximum rootfs size in order to fit in 8GB eMMC
+# this is just a guess using the size reported by fdisk minus the overhead from the boot partitions (72MiB)
+IMAGE_ROOTFS_MAXSIZE = "${@ 7566524416 - (72 * 1024 * 1024) }"

--- a/recipes-images/images/system-astrial-image.bb
+++ b/recipes-images/images/system-astrial-image.bb
@@ -53,7 +53,7 @@ IMAGE_INSTALL:append = " git joe du-dust python3-shtab python3-tldr custom-shell
 # Rootfs will automatically resize to fill entire space by itself, but leave some extra space for initial operations
 # Use overhead factor instead of extra space since there are some problems with the rootfs size estimation which lead to:
 #   Copying files into the device: __populate_fs: Could not allocate block in ext2 filesystem while writing file "..."
-IMAGE_OVERHEAD_FACTOR = "1.05"
+IMAGE_OVERHEAD_FACTOR = "1.06"
 IMAGE_ROOTFS_EXTRA_SPACE = "0"
 # compute maximum rootfs size in order to fit in 8GB eMMC
 # this is just a guess using the size reported by fdisk minus the overhead from the boot partitions (72MiB)

--- a/scripts/astrial-setup-env
+++ b/scripts/astrial-setup-env
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-MACHINE=${MACHINE:-astrial-imx8mp}
+MACHINE=${MACHINE:-astrial-8gb-imx8mp}
 DISTRO=${DISTRO:-fsl-imx-xwayland}
 EULA=1
 T="../sources-extra/meta-sysele-nxp-5.15.71/templates"

--- a/wic/astrial-imx8mp-bootpart.wks.in
+++ b/wic/astrial-imx8mp-bootpart.wks.in
@@ -1,0 +1,20 @@
+# short-description: Create SD card image with a boot partition
+# long-description:
+# Create an image that can be written onto a SD card using dd for use
+# with i.MX SoC family
+# It uses u-boot + other binaries gathered together on imx-boot file
+#
+# The disk layout used is:
+#  - ---------- -------------- --------------
+# | | imx-boot |     boot     |    rootfs    |
+#  - ---------- -------------- --------------
+# ^ ^          ^              ^              ^
+# | |          |              |              |
+# 0 |        8MiB          72MiB          72MiB + rootfs + IMAGE_EXTRA_SPACE
+#   ${IMX_BOOT_SEEK} 32 for imx8mp
+#
+part u-boot --source rawcopy --sourceparams="file=imx-boot" --ondisk mmcblk --no-table --align ${IMX_BOOT_SEEK}
+part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 8192 --fixed-size 64
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 8192 --overhead-factor 1
+
+bootloader --ptable msdos


### PR DESCRIPTION
- Split `astrial-8gb-imx8mp` machine into 3 variants, one for each memory configuration:
  - `conf/machine/astrial-2gb-imx8mp.conf`
  - `conf/machine/astrial-4gb-imx8mp.conf`
  - `conf/machine/astrial-8gb-imx8mp.conf`
- Update `u-boot-imx` to use different defconfigs for each configuration
  - [x] Merge https://github.com/System-Electronics/uboot-imx-lf-5.15.71/pull/1
- Add custom `astrial-imx8mp-bootpart.wks.in` file for setting `overhead-size` to `1` for rootfs partition (yocto already adds  enough overhead)
- To reduce rootfs size and avoid going over 8GB, add custom values for:
  - `IMAGE_OVERHEAD_FACTOR`
  - `IMAGE_ROOTFS_EXTRA_SPACE`
  - `IMAGE_ROOTFS_MAXSIZE`